### PR TITLE
Add Windows binaries to CI packaging workflow

### DIFF
--- a/.github/workflows/package-binaries.yml
+++ b/.github/workflows/package-binaries.yml
@@ -71,17 +71,21 @@ jobs:
         case "${{ matrix.os }}" in
           linux)
             URL="http://www.creatis.insa-lyon.fr/~sdika/soft/ctrDetect-v1_x86_64.tar.gz"
+            curl -L "$URL" -o ctrDetect.tar.gz
+            tar -zxvf ctrDetect.tar.gz
             ;;
           osx)
             URL="http://www.creatis.insa-lyon.fr/~sdika/soft/ctrDetect-v1_macos10.11.tar.gz"
+            curl -L "$URL" -o ctrDetect.tar.gz
+            tar -zxvf ctrDetect.tar.gz
             ;;
           windows)
             URL="http://www.creatis.insa-lyon.fr/~sdika/soft/ctrDetect-v1_win.zip"
+            curl -L "$URL" -o ctrDetect.zip
+            unzip ctrDetect.zip
             ;;
          esac
-        curl -L "$URL" -o ctrDetect.tar.gz
         mkdir -p pkg
-        tar -zxvf ctrDetect.tar.gz
         cp -p ctrDetect/{spine_detect,spine_train_svm}* pkg/
         mv pkg/spine_train_svm pkg/train_svm  # we have this one named unusually
         cp -p ctrDetect/LICENSE.txt pkg/copyright/LICENSE_ctrDetect.txt

--- a/.github/workflows/package-binaries.yml
+++ b/.github/workflows/package-binaries.yml
@@ -68,27 +68,31 @@ jobs:
     - name: get ctrDetect
       run: |
         echo "test test trying to build for ${{ matrix.os }}"
+        mkdir -p pkg
         case "${{ matrix.os }}" in
           linux)
             URL="http://www.creatis.insa-lyon.fr/~sdika/soft/ctrDetect-v1_x86_64.tar.gz"
             curl -L "$URL" -o ctrDetect.tar.gz
             tar -zxvf ctrDetect.tar.gz
+            cp -p ctrDetect/{spine_detect,spine_train_svm} pkg/
+            mv pkg/spine_train_svm pkg/train_svm  # we have this one named unusually
             ;;
           osx)
             URL="http://www.creatis.insa-lyon.fr/~sdika/soft/ctrDetect-v1_macos10.11.tar.gz"
             curl -L "$URL" -o ctrDetect.tar.gz
             tar -zxvf ctrDetect.tar.gz
+            cp -p ctrDetect/{spine_detect,spine_train_svm} pkg/
+            mv pkg/spine_train_svm pkg/train_svm  # we have this one named unusually
             ;;
           windows)
             URL="http://www.creatis.insa-lyon.fr/~sdika/soft/ctrDetect-v1_win.zip"
             curl -L "$URL" -o ctrDetect.zip
             unzip ctrDetect.zip
-            mv ctrDetect-win/ ctrDetect/
+            mv ctrDetect-win/ ctrDetect
+            cp -p ctrDetect/{spine_detect,spine_train_svm}.exe pkg/
+            mv pkg/spine_train_svm.exe pkg/train_svm.exe  # we have this one named unusually
             ;;
          esac
-        mkdir -p pkg
-        cp -p ctrDetect/{spine_detect,spine_train_svm}* pkg/
-        mv pkg/spine_train_svm pkg/train_svm  # we have this one named unusually
         cp -p ctrDetect/LICENSE.txt pkg/copyright/LICENSE_ctrDetect.txt
         cp -p ctrDetect/LICENSE_opencv.txt pkg/copyright/
         chmod 544 pkg/copyright/*  # upstream accidentally marked the licenses as programs, oops.

--- a/.github/workflows/package-binaries.yml
+++ b/.github/workflows/package-binaries.yml
@@ -28,10 +28,10 @@ jobs:
         # TODO: this is currently at kousu/ANTs; get it moved to neuropoly/ANTs
         case "${{ matrix.os }}" in
           linux)
-            URL="https://github.com/spinalcordtoolbox/spinalcordtoolbox-ants/releases/download/r20220512/sct-apps_centos7.tar.gz"
+            URL="https://github.com/spinalcordtoolbox/build_ANTs/releases/download/r20220516/sct-apps_centos7.tar.gz"
             ;;
           osx)
-            URL="https://github.com/spinalcordtoolbox/spinalcordtoolbox-ants/releases/download/r20220512/sct-apps_macos-10.15.tar.gz"
+            URL="https://github.com/spinalcordtoolbox/build_ANTs/releases/download/r20220516/sct-apps_macos-10.15.tar.gz"
             ;;
          esac
         curl -L "$URL" -o spinalcordtoolbox-ants.tar.gz

--- a/.github/workflows/package-binaries.yml
+++ b/.github/workflows/package-binaries.yml
@@ -140,7 +140,11 @@ jobs:
       - uses: actions/download-artifact@v1
         with:
           name: spinalcordtoolbox-binaries_osx
-      
+
+      - uses: actions/download-artifact@v1
+        with:
+          name: spinalcordtoolbox-binaries_windows
+
       - name: Upload Release Asset
         uses: actions/upload-release-asset@v1
         env:
@@ -159,4 +163,14 @@ jobs:
           upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
           asset_path: ./spinalcordtoolbox-binaries_osx/spinalcordtoolbox-binaries_osx.tar.gz
           asset_name: spinalcordtoolbox-binaries_osx.tar.gz
+          asset_content_type: application/gzip
+
+      - name: Upload Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+          asset_path: ./spinalcordtoolbox-binaries_windows/spinalcordtoolbox-binaries_windows.tar.gz
+          asset_name: spinalcordtoolbox-binaries_windows.tar.gz
           asset_content_type: application/gzip

--- a/.github/workflows/package-binaries.yml
+++ b/.github/workflows/package-binaries.yml
@@ -28,13 +28,13 @@ jobs:
         # TODO: this is currently at kousu/ANTs; get it moved to neuropoly/ANTs
         case "${{ matrix.os }}" in
           linux)
-            URL="https://github.com/spinalcordtoolbox/build_ANTs/releases/download/r20220516/sct-apps_centos7.tar.gz"
+            URL="https://github.com/spinalcordtoolbox/build_ANTs/releases/download/r20220516-2/sct-apps_centos7.tar.gz"
             ;;
           osx)
-            URL="https://github.com/spinalcordtoolbox/build_ANTs/releases/download/r20220516/sct-apps_macos-10.15.tar.gz"
+            URL="https://github.com/spinalcordtoolbox/build_ANTs/releases/download/r20220516-2/sct-apps_macos-10.15.tar.gz"
             ;;
           windows)
-            URL="https://github.com/spinalcordtoolbox/build_ANTs/releases/download/r20220516/sct-apps_windows-2019.tar.gz"
+            URL="https://github.com/spinalcordtoolbox/build_ANTs/releases/download/r20220516-2/sct-apps_windows-2019.tar.gz"
             ;;
          esac
         curl -L "$URL" -o spinalcordtoolbox-ants.tar.gz

--- a/.github/workflows/package-binaries.yml
+++ b/.github/workflows/package-binaries.yml
@@ -18,7 +18,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [linux, osx]
+        os: [linux, osx, windows]
     runs-on: ubuntu-latest
     steps:
 
@@ -32,6 +32,9 @@ jobs:
             ;;
           osx)
             URL="https://github.com/spinalcordtoolbox/build_ANTs/releases/download/r20220516/sct-apps_macos-10.15.tar.gz"
+            ;;
+          windows)
+            URL="https://github.com/spinalcordtoolbox/build_ANTs/releases/download/r20220516/sct-apps_windows-2019.tar.gz"
             ;;
          esac
         curl -L "$URL" -o spinalcordtoolbox-ants.tar.gz
@@ -52,6 +55,9 @@ jobs:
           osx)
             URL="https://github.com/spinalcordtoolbox/spinalcordtoolbox-binaries/releases/download/binaries_dev/20161123_sct_binaries_dev_osx.tar.gz"
             ;;
+          windows)
+            URL="https://github.com/spinalcordtoolbox/spinalcordtoolbox-binaries/releases/download/binaries_dev/20220225_sct_binaries_dev_windows.tar.gz"
+            ;;
          esac
         curl -L "$URL" -o spinalcordtoolbox-dev.tar.gz
         mkdir -p pkg
@@ -69,11 +75,14 @@ jobs:
           osx)
             URL="http://www.creatis.insa-lyon.fr/~sdika/soft/ctrDetect-v1_macos10.11.tar.gz"
             ;;
+          windows)
+            URL="http://www.creatis.insa-lyon.fr/~sdika/soft/ctrDetect-v1_win.zip"
+            ;;
          esac
         curl -L "$URL" -o ctrDetect.tar.gz
         mkdir -p pkg
         tar -zxvf ctrDetect.tar.gz
-        cp -p ctrDetect/{spine_detect,spine_train_svm} pkg/
+        cp -p ctrDetect/{spine_detect,spine_train_svm}* pkg/
         mv pkg/spine_train_svm pkg/train_svm  # we have this one named unusually
         cp -p ctrDetect/LICENSE.txt pkg/copyright/LICENSE_ctrDetect.txt
         cp -p ctrDetect/LICENSE_opencv.txt pkg/copyright/

--- a/.github/workflows/package-binaries.yml
+++ b/.github/workflows/package-binaries.yml
@@ -83,6 +83,7 @@ jobs:
             URL="http://www.creatis.insa-lyon.fr/~sdika/soft/ctrDetect-v1_win.zip"
             curl -L "$URL" -o ctrDetect.zip
             unzip ctrDetect.zip
+            mv ctrDetect-win/ ctrDetect/
             ;;
          esac
         mkdir -p pkg

--- a/.github/workflows/package-binaries.yml
+++ b/.github/workflows/package-binaries.yml
@@ -95,7 +95,7 @@ jobs:
          esac
         cp -p ctrDetect/LICENSE.txt pkg/copyright/LICENSE_ctrDetect.txt
         cp -p ctrDetect/LICENSE_opencv.txt pkg/copyright/
-        chmod 544 pkg/copyright/*  # upstream accidentally marked the licenses as programs, oops.
+        chmod 666 pkg/copyright/*  # upstream accidentally marked the licenses as programs, oops.
         
     - name: "'isct_' prefix"
       run: |


### PR DESCRIPTION
This PR incorporates the changes from https://github.com/spinalcordtoolbox/build_ANTs/pull/3 to test Windows binaries built from CI.