### PR TITLE
Update GHA workflow structure to match other repos (`workflow-dispatch`, NodeJS 12 actions, etc.)

### DIFF
--- a/.github/workflows/package-binaries.yml
+++ b/.github/workflows/package-binaries.yml
@@ -139,7 +139,8 @@ jobs:
   release:
     needs: [build]
     runs-on: ubuntu-latest
-    #if: github.event_name == 'push' && github.branch_name == 'master' # only do a release on master
+    # Only attach to release if workflow is run manually. (This allows the workflow to double as a PR test.)
+    if: github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/package-binaries.yml
+++ b/.github/workflows/package-binaries.yml
@@ -114,7 +114,7 @@ jobs:
          esac
         cp -p ctrDetect/LICENSE.txt pkg/copyright/LICENSE_ctrDetect.txt
         cp -p ctrDetect/LICENSE_opencv.txt pkg/copyright/
-        chmod 666 pkg/copyright/*  # upstream accidentally marked the licenses as programs, oops.
+        chmod -x pkg/copyright/*  # upstream accidentally marked the licenses as programs, oops.
         
     - name: "'isct_' prefix"
       run: |

--- a/.github/workflows/package-binaries.yml
+++ b/.github/workflows/package-binaries.yml
@@ -5,7 +5,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
-    
+
 # all this does is collect three dependencies,
 # - spinalcordtoolbox-ants which essentially a more minimal fork of https://github.com/ANTsX/ANTs
 # - spinalcordtoolbox-dev, which comes from https://github.com/neuropoly/spinalcordtoolbox/blob/master/dev
@@ -42,8 +42,8 @@ jobs:
         mkdir -p pkg && cp -rp spinalcordtoolbox-ants/sct-apps/* pkg/
         mkdir -p pkg/copyright
         mv pkg/COPYING.txt pkg/copyright/LICENSE_ANTs.txt
-        
-  
+
+
     # upstream: hhttps://github.com/biomedia-mira/stitching
     - name: get stitching
       run: |
@@ -115,19 +115,19 @@ jobs:
         cp -p ctrDetect/LICENSE.txt pkg/copyright/LICENSE_ctrDetect.txt
         cp -p ctrDetect/LICENSE_opencv.txt pkg/copyright/
         chmod -x pkg/copyright/*  # upstream accidentally marked the licenses as programs, oops.
-        
+
     - name: "'isct_' prefix"
       run: |
         # TODO: there's gotta be a shorter way to do this
         # add the isct_ to programs that don't already have it
         cd pkg
         find ./ -type f -executable ! -name "isct_*" -maxdepth 1 | while read fname; do  mv "$fname" $(dirname "$fname")/isct_$(basename "$fname"); done
-    
+
     - name: package
       run: |
         # Github Artifacts only make .zips, so make a .tar.gz manually to preserve permissions/dates/etc
         tar -zcvf spinalcordtoolbox-binaries_${{ matrix.os }}.tar.gz -C pkg ./
-    
+
     - name: upload result
       uses: actions/upload-artifact@v3
       with:
@@ -138,7 +138,7 @@ jobs:
     needs: [build]
     runs-on: ubuntu-latest
     #if: github.event_name == 'push' && github.branch_name == 'master' # only do a release on master
-    steps:          
+    steps:
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -169,7 +169,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
           asset_path: ./spinalcordtoolbox-binaries_linux.tar.gz
           asset_name: spinalcordtoolbox-binaries_linux.tar.gz
           asset_content_type: application/gzip
@@ -179,7 +179,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
           asset_path: ./spinalcordtoolbox-binaries_osx.tar.gz
           asset_name: spinalcordtoolbox-binaries_osx.tar.gz
           asset_content_type: application/gzip

--- a/.github/workflows/package-binaries.yml
+++ b/.github/workflows/package-binaries.yml
@@ -1,10 +1,12 @@
 name: Package SCT C++ binaries
 
 on:
-  push:
-    branches: [ master ]
   pull_request:
-    branches: [ master ]
+  workflow_dispatch:
+    inputs:
+      release_title:
+        description: 'Release title (e.g. rYYYYMMDD)'
+        required: true
 
 # all this does is collect three dependencies,
 # - spinalcordtoolbox-ants which essentially a more minimal fork of https://github.com/ANTsX/ANTs
@@ -155,9 +157,7 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          # name the release with the run_id to allow multiple builds on the same branch/tag
-          # https://github.com/actions/create-release/issues/2#issuecomment-613591846
-          tag: ${{ github.ref }}-${{github.run_id }}
+          tag: ${{ github.event.inputs.release_title }}
           name: Release ${{ github.sha }}
           draft: false
           prerelease: true

--- a/.github/workflows/package-binaries.yml
+++ b/.github/workflows/package-binaries.yml
@@ -139,19 +139,6 @@ jobs:
     runs-on: ubuntu-latest
     #if: github.event_name == 'push' && github.branch_name == 'master' # only do a release on master
     steps:
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          # name the release with the run_id to allow multiple builds on the same branch/tag
-          # https://github.com/actions/create-release/issues/2#issuecomment-613591846
-          tag_name: ${{ github.ref }}-${{github.run_id }}
-          release_name: Release ${{ github.sha }}
-          draft: false
-          prerelease: true
-
       - uses: actions/download-artifact@v3
         with:
           name: spinalcordtoolbox-binaries_linux
@@ -164,32 +151,15 @@ jobs:
         with:
           name: spinalcordtoolbox-binaries_windows
 
-      - name: Upload Release Asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create Release
+        uses: ncipollo/release-action@v1
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          asset_path: ./spinalcordtoolbox-binaries_linux.tar.gz
-          asset_name: spinalcordtoolbox-binaries_linux.tar.gz
-          asset_content_type: application/gzip
-
-      - name: Upload Release Asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          asset_path: ./spinalcordtoolbox-binaries_osx.tar.gz
-          asset_name: spinalcordtoolbox-binaries_osx.tar.gz
-          asset_content_type: application/gzip
-
-      - name: Upload Release Asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          asset_path: ./spinalcordtoolbox-binaries_windows.tar.gz
-          asset_name: spinalcordtoolbox-binaries_windows.tar.gz
-          asset_content_type: application/gzip
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # name the release with the run_id to allow multiple builds on the same branch/tag
+          # https://github.com/actions/create-release/issues/2#issuecomment-613591846
+          tag: ${{ github.ref }}-${{github.run_id }}
+          name: Release ${{ github.sha }}
+          draft: false
+          prerelease: true
+          artifacts: "spinalcordtoolbox-binaries_linux.tar.gz,spinalcordtoolbox-binaries_osx.tar.gz,spinalcordtoolbox-binaries_windows.tar.gz"
+          artifactContentType: application/gzip

--- a/.github/workflows/package-binaries.yml
+++ b/.github/workflows/package-binaries.yml
@@ -152,15 +152,15 @@ jobs:
           draft: false
           prerelease: true
 
-      - uses: actions/download-artifact@v1
+      - uses: actions/download-artifact@v3
         with:
           name: spinalcordtoolbox-binaries_linux
-          
-      - uses: actions/download-artifact@v1
+
+      - uses: actions/download-artifact@v3
         with:
           name: spinalcordtoolbox-binaries_osx
 
-      - uses: actions/download-artifact@v1
+      - uses: actions/download-artifact@v3
         with:
           name: spinalcordtoolbox-binaries_windows
 
@@ -170,17 +170,17 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-          asset_path: ./spinalcordtoolbox-binaries_linux/spinalcordtoolbox-binaries_linux.tar.gz
+          asset_path: ./spinalcordtoolbox-binaries_linux.tar.gz
           asset_name: spinalcordtoolbox-binaries_linux.tar.gz
           asset_content_type: application/gzip
-          
+
       - name: Upload Release Asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-          asset_path: ./spinalcordtoolbox-binaries_osx/spinalcordtoolbox-binaries_osx.tar.gz
+          asset_path: ./spinalcordtoolbox-binaries_osx.tar.gz
           asset_name: spinalcordtoolbox-binaries_osx.tar.gz
           asset_content_type: application/gzip
 
@@ -190,6 +190,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          asset_path: ./spinalcordtoolbox-binaries_windows/spinalcordtoolbox-binaries_windows.tar.gz
+          asset_path: ./spinalcordtoolbox-binaries_windows.tar.gz
           asset_name: spinalcordtoolbox-binaries_windows.tar.gz
           asset_content_type: application/gzip

--- a/.github/workflows/package-binaries.yml
+++ b/.github/workflows/package-binaries.yml
@@ -129,7 +129,7 @@ jobs:
         tar -zcvf spinalcordtoolbox-binaries_${{ matrix.os }}.tar.gz -C pkg ./
     
     - name: upload result
-      uses: actions/upload-artifact@v2-preview
+      uses: actions/upload-artifact@v3
       with:
         name: spinalcordtoolbox-binaries_${{ matrix.os }}
         path: spinalcordtoolbox-binaries_${{ matrix.os }}.tar.gz

--- a/.github/workflows/package-binaries.yml
+++ b/.github/workflows/package-binaries.yml
@@ -160,7 +160,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ github.event.inputs.release_title }}
           name: Release ${{ github.sha }}
-          draft: false
-          prerelease: true
+          draft: true
           artifacts: "spinalcordtoolbox-binaries_linux.tar.gz,spinalcordtoolbox-binaries_osx.tar.gz,spinalcordtoolbox-binaries_windows.tar.gz"
           artifactContentType: application/gzip


### PR DESCRIPTION
This PR updates the structure of the workflow file to match the conventions we've developed in other repos. Namely: 

- Using `workflow-dispatch` to manually trigger the release
- Setting an `if:` condition so that, for PRs, every step is run _but_ the actual release step
- Using up to date versions of third-party actions (replacing `actions/` with `ncipollo/`)

<details>
<summary> Original PR description (Upgrading outdated NodeJS 12 actions) </summary>

I made several trivial upgrades of node12 actions that Github Actions warns about today, but this one is more involved. I'm not sure how to test it, so maybe this should stay as a draft PR until we're ready to create a new release of the SCT binaries?

Although, since this also fixes a permissions bug, maybe we could make a release?

This should address the following warnings from Github Actions:

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/upload-artifact

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/create-release, actions/upload-release-asset, actions/upload-release-asset, actions/upload-release-asset

> The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

It also replaces the archived, unmaintained actions `actions/create-release` and `actions/upload-release-asset` with `ncipollo/release-action`, which is maintained and which we use for other repos already.

</summary>